### PR TITLE
ci: add GitHub Action to build PyInstaller executables for releases

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -1,0 +1,82 @@
+name: Build standalone executables
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install system deps (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libglib2.0-0
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pyinstaller
+
+      - name: Build executable (PyInstaller)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          pyinstaller --name aind-data-transfer-lite-ui --windowed src\aind_data_transfer_lite\ui.py
+
+      - name: Build executable (PyInstaller) - Linux/macOS
+        if: matrix.os != 'windows-latest'
+        run: |
+          pyinstaller --name aind-data-transfer-lite-ui --windowed src/aind_data_transfer_lite/ui.py
+
+      # ---- Package per OS ----
+
+      - name: Zip app bundle (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path dist\aind-data-transfer-lite-ui -DestinationPath aind-data-transfer-lite-ui-windows.zip
+
+      - name: Zip app bundle (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent dist/aind-data-transfer-lite-ui aind-data-transfer-lite-ui-macos.zip
+
+      - name: Zip app bundle (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          zip -r aind-data-transfer-lite-ui-linux.zip dist/aind-data-transfer-lite-ui
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aind-data-transfer-lite-ui-${{ matrix.os }}
+          path: "*.zip"
+
+      - name: Upload to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: "*.zip"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #29 

This PR adds a GitHub Actions workflow (build_exe.yml) to automatically build standalone executables for Windows, macOS, and Linux when a release is published, and to upload them as artifacts attached to that release.

Notes:
- This workflow is release-triggered and also supports workflow_dispatch for manual runs
- The workflow will not appear in the Actions tab until it is merged into main
- I am unable to fully test the release-automation process in my personal fork because the repository secrets (GITHUB_TOKEN, PyPI tokens, etc.) are not available outside the main repo. Testing will be possible once this PR is merged into the upstream repository
- The automatic creation of the executables does succeed in my personal forked repo

After merge, we can trigger a test release (f that sounds OK) or use workflow_dispatch to confirm the new Action has been added to the repo + the executables are built and attached correctly

Let me know if I've missed anything!